### PR TITLE
fix: ensure gateway install before start/restart on macOS

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -269,11 +269,24 @@ export function runSetupStream(profile, apiKey, modelId, channel, channelCreds, 
         onProgress(85, "Warning: failed to apply final config: " + cfgErr.message);
       }
 
-      onProgress(92, "Restarting gateway...");
+      onProgress(88, "Installing gateway service...");
+      var serviceInstalled = false;
       try {
-        execSafe("openclaw", [...profileArgs(profile), "gateway", "restart"]);
-      } catch (restartErr) {
-        onProgress(92, "Warning: gateway restart failed: " + restartErr.message);
+        execSafe("openclaw", [...profileArgs(profile), "gateway", "install"]);
+        serviceInstalled = true;
+      } catch (installErr) {
+        onProgress(88, "Warning: gateway service install failed — you may need to run 'openclaw" +
+          (profile === "default" ? "" : " --profile " + profile) +
+          " gateway install' manually in Terminal. (" + installErr.message + ")");
+      }
+
+      if (serviceInstalled) {
+        onProgress(92, "Starting gateway...");
+        try {
+          execSafe("openclaw", [...profileArgs(profile), "gateway", "start"]);
+        } catch (startErr) {
+          onProgress(92, "Warning: gateway start failed: " + startErr.message);
+        }
       }
 
       onProgress(100, "Done");
@@ -319,8 +332,12 @@ export function connectTelegramUser(profile, telegramId, onProgress) {
 }
 
 export function startGateway(profile) {
-  const port = readPort(profile);
-  execSafe("openclaw", [...profileArgs(profile), "gateway", "start", "--port", String(port)], { stdio: "inherit" });
+  // First ensure the service is installed (launchd/systemd), then start it
+  // Port is read from config by the gateway itself
+  try {
+    execSafe("openclaw", [...profileArgs(profile), "gateway", "install"]);
+  } catch {}
+  execSafe("openclaw", [...profileArgs(profile), "gateway", "start"], { stdio: "inherit" });
 }
 
 export function stopGateway(profile) {
@@ -354,6 +371,10 @@ export function changeModel(profile, modelId) {
 }
 
 export function restartGateway(profile) {
+  // Ensure service is registered first (macOS gateway stop does launchctl bootout)
+  try {
+    execSafe("openclaw", [...profileArgs(profile), "gateway", "install"]);
+  } catch {}
   execSafe("openclaw", [...profileArgs(profile), "gateway", "restart"]);
 }
 


### PR DESCRIPTION
## Problem

On macOS, users encounter "Gateway service not loaded" after deploying via OpenClaw Manager.

The root cause: `onboard --install-daemon` may silently fail to register the LaunchAgent plist (e.g. due to macOS permission prompts during first install), and `gateway stop` may unload the plist via `launchctl bootout`. After either case, `gateway start` and `gateway restart` fail because the service is no longer registered with launchd.

## Fix

Call `gateway install` (idempotent) before every `start`/`restart` to ensure the LaunchAgent plist is always registered:

- **`runSetupStream()`**: explicit `gateway install` after onboard completes, with clear error message if install fails (tells user to run manually in Terminal)
- **`startGateway()`**: `gateway install` before `start`
- **`restartGateway()`**: `gateway install` before `restart`

Also removes unnecessary `--port` flag from `startGateway()` since the gateway reads port from its config file.

## Testing

- `gateway install` is idempotent — safe to call multiple times
- Covers both first-install and stop-then-start scenarios